### PR TITLE
on linux, only remap tilt for wii/ps3rb instruments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@
 *.dSYM/
 *.su
 .vscode
+result

--- a/dumbxinputemu/dinput_input.c
+++ b/dumbxinputemu/dinput_input.c
@@ -716,14 +716,14 @@ static void dinput_joystate_to_xinput(DIJOYSTATE2 *js, XINPUT_GAMEPAD_EX *gamepa
             if (js->rgbButtons[i] & 0x80)
                 gamepad->wButtons |= raph_psx_buttons[i];
     }
-    else if (caps->ps3rb)
+    else if (caps->ps3rb && (caps->macos || caps->windows))
     {
         buttons = min(caps->buttons, sizeof(ps3_buttons) / sizeof(*ps3_buttons));
         for (i = 0; i < buttons; i++)
             if (js->rgbButtons[i] & 0x80)
                 gamepad->wButtons |= ps3_buttons[i];
     }
-    else if (caps->ps4rb || caps->ps5rb)
+    else if (caps->ps3rb || caps->ps4rb || caps->ps5rb) // hid-sony makes these all use ps4_buttons on linux 7+
     {
         buttons = min(caps->buttons, sizeof(ps4_buttons) / sizeof(*ps4_buttons));
         for (i = 0; i < buttons; i++)

--- a/dumbxinputemu/dinput_input.c
+++ b/dumbxinputemu/dinput_input.c
@@ -484,6 +484,23 @@ static void dinput_joystate_to_xinput(DIJOYSTATE2 *js, XINPUT_GAMEPAD_EX *gamepa
         XINPUT_GAMEPAD_Y,
         XINPUT_GAMEPAD_X,
         XINPUT_GAMEPAD_LEFT_SHOULDER};
+
+    static const int ps_linux_buttons[] = {
+        XINPUT_GAMEPAD_A,
+        XINPUT_GAMEPAD_B,
+        XINPUT_GAMEPAD_Y,
+        XINPUT_GAMEPAD_X,
+        XINPUT_GAMEPAD_LEFT_SHOULDER,
+        0x00,                          // tilt - sent as a synthetic axis in ps3rb
+        XINPUT_GAMEPAD_BACK,
+        XINPUT_GAMEPAD_START,
+        XINPUT_GAMEPAD_LEFT_THUMB,
+        XINPUT_GAMEPAD_RIGHT_THUMB,
+        XINPUT_GAMEPAD_GUIDE,
+        0x00,
+        XINPUT_GAMEPAD_START           // 12 (map p1 to start so clicking in the joystick works)
+    };
+
     static const int xbox_buttons[] = {
         XINPUT_GAMEPAD_A,
         XINPUT_GAMEPAD_B,
@@ -716,19 +733,31 @@ static void dinput_joystate_to_xinput(DIJOYSTATE2 *js, XINPUT_GAMEPAD_EX *gamepa
             if (js->rgbButtons[i] & 0x80)
                 gamepad->wButtons |= raph_psx_buttons[i];
     }
-    else if (caps->ps3rb && (caps->macos || caps->windows))
+    else if (caps->ps3rb || caps->ps4rb || caps->ps5rb)
     {
-        buttons = min(caps->buttons, sizeof(ps3_buttons) / sizeof(*ps3_buttons));
-        for (i = 0; i < buttons; i++)
-            if (js->rgbButtons[i] & 0x80)
-                gamepad->wButtons |= ps3_buttons[i];
-    }
-    else if (caps->ps3rb || caps->ps4rb || caps->ps5rb) // hid-sony makes these all use ps4_buttons on linux 7+
-    {
-        buttons = min(caps->buttons, sizeof(ps4_buttons) / sizeof(*ps4_buttons));
-        for (i = 0; i < buttons; i++)
-            if (js->rgbButtons[i] & 0x80)
-                gamepad->wButtons |= ps4_buttons[i];
+        if (caps->macos || caps->windows)
+        {
+            if (caps->ps3rb)
+            {
+                buttons = min(caps->buttons, sizeof(ps3_buttons) / sizeof(*ps3_buttons));
+                for (i = 0; i < buttons; i++)
+                    if (js->rgbButtons[i] & 0x80)
+                        gamepad->wButtons |= ps3_buttons[i];
+            }
+            else
+            {
+                buttons = min(caps->buttons, sizeof(ps4_buttons) / sizeof(*ps4_buttons));
+                for (i = 0; i < buttons; i++)
+                    if (js->rgbButtons[i] & 0x80)
+                        gamepad->wButtons |= ps4_buttons[i];
+            }
+        } else
+        {
+            buttons = min(caps->buttons, sizeof(ps_linux_buttons) / sizeof(*ps_linux_buttons));
+            for (i = 0; i < buttons; i++)
+                if (js->rgbButtons[i] & 0x80)
+                    gamepad->wButtons |= ps_linux_buttons[i];
+        }
     }
     else if (caps->ps3gh)
     {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772047000,
+        "narHash": "sha256-7DaQVv4R97cii/Qdfy4tmDZMB2xxtyIvNGSwXBBhSmo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1267bb4920d0fc06ea916734c11b0bf004bbe17e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,58 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+        in
+        {
+          default = pkgs.stdenv.mkDerivation {
+            pname = "xinputemu";
+            version = "0.42";
+            src = ./.;
+
+            # Inject both 32-bit and 64-bit MinGW toolchains into the environment PATH.
+            nativeBuildInputs = [
+              pkgs.pkgsCross.mingw32.stdenv.cc
+              pkgs.pkgsCross.mingwW64.stdenv.cc
+            ];
+
+            # Override the Makefile's hardcoded `/usr/...` paths via makeFlags.
+            # Nix's cc wrappers automatically handle the inclusion of Windows SDK 
+            # headers (like wbemidl.h) and libraries, so we only need to preserve 
+            # local includes.
+            makeFlags = [
+              "GCC32=i686-w64-mingw32-gcc"
+              "GCC64=x86_64-w64-mingw32-gcc"
+              "INCLUDE_DIR32=-Idumbxinputemu"
+              "INCLUDE_DIR64=-Idumbxinputemu"
+              "LIB_DIR32="
+              "LIB_DIR64="
+            ];
+
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p $out
+              cp -r build/32 $out/
+              cp -r build/64 $out/
+              
+              if [ -f setup_dumbxinputemu.verb ]; then
+                cp setup_dumbxinputemu.verb $out/
+              fi
+
+              runHook postInstall
+            '';
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Using `xinputemu` after the [`hid-sony` patch](https://github.com/Rosalie241/hid-sony) took some tinkering:

- This patch exempts Linux from the prior `ps3_buttons` map, standardizing on the same `ps4_buttons` map as `hid-sony`.
- **IMPORTANT**: Must use Proton v9.  I spent hours last night trying to figure out why it wasn't taking hold, only to realize that Proton v10 swallows all the HID devices, even if SDL and Steam Input are off.  Only discovered it when I rebuilt with `#define DEBUG` on and saw that only a `11ff28de` controller (that Steam/Proton was apparently making up) was appearing.

I left the old `ps3_buttons` intact to not break users on other platforms.  Happy to rename it if you like.

There are a couple other commits I needed to get it to build.  Can keep them in my fork if you don't want them upstream too.